### PR TITLE
New functionalities: alternating case format, open image in browser, and save image locally / open locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ In order to start using Memey, you first need to create an account on <https://i
 Once you have logged in, you can start using Memey to create memes. In order to do so, you must run the `meme` command and pass it three options. This generates a url that automatically gets copied to your clipbwoard.
 
 - `s` - The search query. Memey will attempt to find a meme that matches the results.
+- `a` (optional)* - Format any top or bottom text with aLtErNaTiNg CaSe :)
+- `o` (optional) - Open image in browser immediately after creation
+- `l` (optional) - The image will be saved locally in the `/images` folder and be opened locally immediately after creation
 - `t` (optional)* - The Top text.
 - `b` (optional)* - The Bottom text.
 
-*While the top and bottom texts are both optional, at least one _must_ be provided.
+*While the top and bottom texts are both optional, at least one _must_ be provided. Additionally, specifying the alternating case flag `a` uses imgflip's more advanced [boxes](https://api.imgflip.com/) API for text placement. Currently no x, y, width, or height parameters are passed, so imgflip attempts to fit the text to the meme as best it can.
 
 #### Example
 
@@ -47,6 +50,14 @@ meme "what if i told you this app was made out of boredom"
 ```
 
 ![](http://i.imgflip.com/1wv44a.jpg)
+
+#### Example
+
+```
+meme -as "mocking spongebob" -t "i am imgflip" -b "i have to be complicated to do alternating case text"
+```
+
+![](https://i.imgflip.com/3dr07s.jpg)
 
 ## Maintenance
 

--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,0 +1,4 @@
+# ignore any images generated in this folder, but not the folder itself
+*
+*/
+!.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,6 +352,14 @@
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
       "integrity": "sha1-HSuFQVjsgWkRPGy39raAHpniEdU="
     },
+    "image-downloader": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/image-downloader/-/image-downloader-3.5.0.tgz",
+      "integrity": "sha512-7n6xFEcelGaJHy3Zq/D/H78BOZtdTo2f7KiI5vxGkvJT0pcz/7LcDShSr3MwRudgIG9/QY0mxEakQ9SAExFMzg==",
+      "requires": {
+        "request": "^2.88.0"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -509,6 +517,21 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.0.tgz",
+      "integrity": "sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==",
+      "requires": {
+        "is-wsl": "^2.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+        }
       }
     },
     "opn": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "clipboardy": "^2.1.0",
-    "opn": "^5.5.0",
+    "image-downloader": "^3.5.0",
+    "open": "^7.0.0",
     "prompt": "^1.0.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",


### PR DESCRIPTION
Hi! 

Love the idea behind this tool, it was exactly what I had in mind and I was happy to see someone beat me too it! It saved me a lot of time 👍 I wanted to add aLtErNaTiNg CaSe 😂 functionality (super useful and funny for the mocking spongebob, for example)

So here's a summary of what I did:

-when the `a` flag is passed, I use imgflips boxes component of the API which allows full control of the text (so far i didn't try to fool around with the coordinates, I just needed the text functionality which perserves all different capitalizations)

-upgraded deprecated 'opn' to the newer 'open', added alternating casetext format functionality

-added open in browser functionality (which seemed to be there already but was never activated?) 

-added a  download / open locally option (and thus an images/ folder). 

-README.md updated with all the new flags and an alternating case example as well

Also to note: there is a small bug I noticed (even before my changes) and that is that the meme name MUST be the string following the `-s` argument. If it is not, you get an error on the `codify` regex line in `index.js` - could be something I could look into later (though now that I think about it, I guess that is expected behaviour - though it could fail more gracefully in this case)

Let me know what you think!

Cheers! 🍺 
